### PR TITLE
Change `sort-imports` rule for `organize-imports`

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -6,18 +6,22 @@ rules = [
   NoAutoTupling
   NoInfer
   NoValInForComprehension
+  OrganizeImports
   ProcedureSyntax
-  SortImports
 ]
 
-SortImports.blocks = [
-  "java.",
-  "scala.",
-  "cats.",
-  "sbt.",
-  "*",
-  "com.sun."
-]
+OrganizeImports {
+  expandRelative = true
+  removeUnused = false
+  groups = [
+    "re:java?\\.",
+    "scala.",
+    "cats.",
+    "sbt.",
+    "*",
+    "com.sun."
+  ]
+}
 
 Disable.symbols = [
   {

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ addSbtPlugin("com.alejandrohdezma" %% "sbt-scalafix-defaults" % "@VERSION@")
 
 ## Usage
 
-The included plugin is automatically activated. It will add some defualt dependencies to `scalafixDependencies` and create a `.scalafix.conf` in your project's root folder with [this content](https://github.com/alejandrohdezma/sbt-scalafix-defaults/blob/master/.scalafix.conf).
+The included plugin activated automatically. It will add some default dependencies to `scalafixDependencies` and create a `.scalafix.conf` in your project's root folder with [this content](https://github.com/alejandrohdezma/sbt-scalafix-defaults/blob/master/.scalafix.conf).
 
 > You can add the `.scalafix.conf` file to the repository's `.gitignore`, since it's going to be automatically re-created on every build.
 

--- a/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
+++ b/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
@@ -28,9 +28,9 @@ object ScalafixDependenciesPlugin extends AutoPlugin {
 
     /** Scalafix dependencies added by this plugin */
     lazy val scalafixDefaultDependencies: Seq[ModuleID] = Seq(
-      "com.github.vovapolu" %% "scaluzzi"         % "0.1.7",
-      "com.nequissimus"     %% "sort-imports"     % "0.4.1",
-      "com.eed3si9n.fix"    %% "scalafix-noinfer" % "0.1.0-M1"
+      "com.eed3si9n.fix"     %% "scalafix-noinfer" % "0.1.0-M1",
+      "com.github.liancheng" %% "organize-imports" % "0.2.1",
+      "com.github.vovapolu"  %% "scaluzzi"         % "0.1.7"
     )
 
   }

--- a/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/simple/expected.conf
+++ b/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/simple/expected.conf
@@ -12,18 +12,22 @@ rules = [
   NoAutoTupling
   NoInfer
   NoValInForComprehension
+  OrganizeImports
   ProcedureSyntax
-  SortImports
 ]
 
-SortImports.blocks = [
-  "java.",
-  "scala.",
-  "cats.",
-  "sbt.",
-  "*",
-  "com.sun."
-]
+OrganizeImports {
+  expandRelative = true
+  removeUnused = false
+  groups = [
+    "re:java?\\.",
+    "scala.",
+    "cats.",
+    "sbt.",
+    "*",
+    "com.sun."
+  ]
+}
 
 Disable.symbols = [
   {


### PR DESCRIPTION
# What has been done in this PR?

Change previously used rule for organizing imports ([NeQuissimus/sort-imports](https://github.com/NeQuissimus/sort-imports)) to [liancheng/scalafix-organize-imports](https://github.com/liancheng/scalafix-organize-imports).

This change includes a breaking change that will provoke to [expand relative imports](https://github.com/liancheng/scalafix-organize-imports#22-expandrelative) and [explode grouped ones](https://github.com/liancheng/scalafix-organize-imports#23-groupedimports).
