### PR TITLE
Remove `scala.Any` from `NoInfer` and `Disable` rules

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -221,7 +221,6 @@ Disable.symbols = [
 
 Disable.ifSynthetic = [
   "java/io/Serializable"
-  "scala/Any"
   "scala/Product"
   "scala/Option.option2Iterable"
   "scala/Predef.any2stringadd"
@@ -267,7 +266,6 @@ DisableSyntax {
 
 NoInfer.symbols = [
   "scala.AnyVal"
-  "scala.Any"
   "java.io.Serializable"
   "scala.Product."
   "scala.Predef.any2stringadd"

--- a/modules/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/extra/expected.conf
+++ b/modules/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/extra/expected.conf
@@ -221,7 +221,6 @@ Disable.symbols = [
 
 Disable.ifSynthetic = [
   "java/io/Serializable"
-  "scala/Any"
   "scala/Product"
   "scala/Option.option2Iterable"
   "scala/Predef.any2stringadd"
@@ -267,7 +266,6 @@ DisableSyntax {
 
 NoInfer.symbols = [
   "scala.AnyVal"
-  "scala.Any"
   "java.io.Serializable"
   "scala.Product."
   "scala.Predef.any2stringadd"

--- a/modules/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/simple/expected.conf
+++ b/modules/sbt-scalafix-defaults/src/sbt-test/sbt-scalafix-defaults/simple/expected.conf
@@ -221,7 +221,6 @@ Disable.symbols = [
 
 Disable.ifSynthetic = [
   "java/io/Serializable"
-  "scala/Any"
   "scala/Product"
   "scala/Option.option2Iterable"
   "scala/Predef.any2stringadd"
@@ -267,7 +266,6 @@ DisableSyntax {
 
 NoInfer.symbols = [
   "scala.AnyVal"
-  "scala.Any"
   "java.io.Serializable"
   "scala.Product."
   "scala.Predef.any2stringadd"


### PR DESCRIPTION
Remove `Any` from these two rules since it causes lots of false-positives.