### PR TITLE
Stop setting `scalafixOnCompile` to true

### DIFF
--- a/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/SbtScalafixDefaults.scala
+++ b/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/SbtScalafixDefaults.scala
@@ -38,7 +38,6 @@ object SbtScalafixDefaults extends AutoPlugin {
   )
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
-    scalafixOnCompile     := !sys.env.contains("CI"),
     scalafixDependencies ++= scalafixDefaultDependencies
   )
 


### PR DESCRIPTION
Most IDEs already run Scalafix on your code on saving so this setting just makes everything slower in most cases