### PR TITLE
Support Scalafix 0.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ addCommandAlias("ci-test", "fix --check; mdoc; scripted")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "github; ci-release")
 
-lazy val scalafix = "ch.epfl.scala" % "sbt-scalafix" % "[0.9.0,)" % Provided // scala-steward:off
+lazy val scalafix = "ch.epfl.scala" % "sbt-scalafix" % "[0.11.0,)" % Provided // scala-steward:off
 
 lazy val documentation = project
   .enablePlugins(MdocPlugin)

--- a/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
+++ b/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
@@ -18,7 +18,7 @@ package com.alejandrohdezma.sbt.scalafix.defaults
 
 import sbt._
 
-/** This plugin just exposes the default Scalafix dependencies to they can be automatically updated by `scala-steward`.
+/** This plugin just exposes the default Scalafix dependencies so they can be automatically updated by `scala-steward`.
   */
 object ScalafixDependenciesPlugin extends AutoPlugin {
 
@@ -26,8 +26,7 @@ object ScalafixDependenciesPlugin extends AutoPlugin {
 
     /** Scalafix dependencies added by this plugin */
     lazy val scalafixDefaultDependencies: Seq[ModuleID] = Seq(
-      "com.github.liancheng" %% "organize-imports" % "0.6.0",
-      "com.github.vovapolu"  %% "scaluzzi"         % "0.1.23"
+      "com.github.vovapolu"  %% "scaluzzi" % "0.1.23"
     )
 
   }

--- a/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
+++ b/modules/sbt-scalafix-defaults/src/main/scala/com/alejandrohdezma/sbt/scalafix/defaults/ScalafixDependenciesPlugin.scala
@@ -26,7 +26,7 @@ object ScalafixDependenciesPlugin extends AutoPlugin {
 
     /** Scalafix dependencies added by this plugin */
     lazy val scalafixDefaultDependencies: Seq[ModuleID] = Seq(
-      "com.github.vovapolu"  %% "scaluzzi" % "0.1.23"
+      "com.github.vovapolu" %% "scaluzzi" % "0.1.23"
     )
 
   }


### PR DESCRIPTION
Scalafix 0.11.0 includes `OrganizeImports` by default, so we can remove it from this library.